### PR TITLE
DPoP Authorization Code Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ enable = true
 properties.header_validity_period = 90
 properties.skip_dpop_validation_in_revoke = "true"
 
+[[event_handler]]
+name= "dpopEventHandler"
+subscriptions =["POST_ISSUE_CODE"]
+
 [[oauth.custom_token_validator]]
 type = "dpop"
 class = "org.wso2.carbon.identity.oauth2.dpop.validators.DPoPTokenValidator"

--- a/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
@@ -41,6 +41,16 @@
             <artifactId>org.wso2.carbon.database.utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
@@ -51,6 +61,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple.wso2</groupId>
@@ -125,6 +139,8 @@
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2;
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.authz.*;
+                            version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.token.*;
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.dto;
@@ -145,8 +161,16 @@
                             version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.cache.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.event.*;
+                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy;
                             version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils;
+                            version="${carbon.kernel.imp.pkg.version.range}",
                             org.apache.catalina.*;version="${apache.catalina.version}",
                             org.wso2.carbon.database.utils.*;
                             version="${org.wso2.carbon.database.utils.version.range}",

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCache.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.cache;
+
+import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationBaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Cache for DPoP JKT.
+ */
+public class DPoPJKTCache extends AuthenticationBaseCache<DPoPJKTCacheKey, DPoPJKTCacheEntry> {
+
+    private static final String DPOP_JKT_CACHE_NAME = "DPoPJKTCache";
+
+    private static volatile DPoPJKTCache instance = new DPoPJKTCache();
+
+    private DPoPJKTCache() {
+
+        super(DPOP_JKT_CACHE_NAME);
+    }
+
+    public static DPoPJKTCache getInstance() {
+
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (DPoPJKTCache.class) {
+                if (instance == null) {
+                    instance = new DPoPJKTCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheEntry.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheEntry.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+
+/**
+ * Cache entry for DPoP JKT.
+ */
+public class DPoPJKTCacheEntry extends CacheEntry {
+
+    private String dpopJkt;
+
+    public DPoPJKTCacheEntry(String dpopJkt) {
+
+        this.dpopJkt = dpopJkt;
+    }
+
+    public String getDpopJkt() {
+
+        return dpopJkt;
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheKey.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheKey.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.cache;
+
+import java.io.Serializable;
+
+/**
+ * Cache key for DPoP JKT.
+ */
+public class DPoPJKTCacheKey implements Serializable {
+
+    private String cacheKeyString;
+
+    public DPoPJKTCacheKey(String clientId, String authzCode) {
+
+        this.cacheKeyString = clientId + ":" + authzCode;
+    }
+
+    private static final long serialVersionUID = 5023478840178742769L;
+    public String getCacheKeyString() {
+
+        return cacheKeyString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (!(o instanceof DPoPJKTCacheKey)) {
+            return false;
+        }
+        return this.cacheKeyString.equals(((DPoPJKTCacheKey) o).getCacheKeyString());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return cacheKeyString.hashCode();
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheKey.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/cache/DPoPJKTCacheKey.java
@@ -27,12 +27,13 @@ public class DPoPJKTCacheKey implements Serializable {
 
     private String cacheKeyString;
 
+    private static final long serialVersionUID = 5023478840178742769L;
+
     public DPoPJKTCacheKey(String clientId, String authzCode) {
 
         this.cacheKeyString = clientId + ":" + authzCode;
     }
 
-    private static final long serialVersionUID = 5023478840178742769L;
     public String getCacheKeyString() {
 
         return cacheKeyString;

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
@@ -31,7 +31,6 @@ public class DPoPConstants {
     public static final String DPOP_ACCESS_TOKEN_HASH = "ath";
     public static final String DPOP_JWT_TYPE = "dpop+jwt";
     public static final String DPOP_TOKEN_TYPE = "DPoP";
-    public static final String EXPIRED_DPOP_PROOF = "Expired DPoP Proof";
     public static final String INVALID_DPOP_PROOF = "invalid_dpop_proof";
     public static final String INVALID_DPOP_ERROR = "Invalid DPoP Proof";
     public static final String INVALID_CLIENT = "invalid_client";
@@ -45,20 +44,12 @@ public class DPoPConstants {
     public static final String CNF = "cnf";
     public static final String TOKEN_TYPE = "token_type";
     public static final String JWK_THUMBPRINT = "jkt";
+    public static final String DPOP_JKT_TABLE_NAME = "IDN_OAUTH2_DPOP_JKT";
+    public static final String DPOP_JKT = "dpop_jkt";
     public static final String AUTHORIZATION_HEADER = "authorization";
+    public static final String CLIENT_ID = "client_id";
+    public static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorization_code";
     public static final String OAUTH_REVOKE_ENDPOINT = "/oauth2/revoke";
     public static final String SKIP_DPOP_VALIDATION_IN_REVOKE = "skip_dpop_validation_in_revoke";
     public static final boolean DEFAULT_SKIP_DPOP_VALIDATION_IN_REVOKE_VALUE = true;
-
-    /**
-     * This class defines SQLQueries.
-     */
-    public static class SQLQueries {
-
-        public static final String RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN =
-                "SELECT BINDING.TOKEN_BINDING_TYPE,BINDING.TOKEN_BINDING_VALUE,BINDING.TOKEN_BINDING_REF " +
-                        "FROM IDN_OAUTH2_ACCESS_TOKEN TOKEN LEFT JOIN IDN_OAUTH2_TOKEN_BINDING BINDING ON " +
-                        "TOKEN.TOKEN_ID=BINDING.TOKEN_ID WHERE TOKEN.REFRESH_TOKEN = ? " +
-                        "AND BINDING.TOKEN_BINDING_TYPE = ?";
-    }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
@@ -31,6 +31,7 @@ public class DPoPConstants {
     public static final String DPOP_ACCESS_TOKEN_HASH = "ath";
     public static final String DPOP_JWT_TYPE = "dpop+jwt";
     public static final String DPOP_TOKEN_TYPE = "DPoP";
+    public static final String EXPIRED_DPOP_PROOF = "Expired DPoP Proof";
     public static final String INVALID_DPOP_PROOF = "invalid_dpop_proof";
     public static final String INVALID_DPOP_ERROR = "Invalid DPoP Proof";
     public static final String INVALID_CLIENT = "invalid_client";

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAO.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAO.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.identity.oauth2.dpop.dao;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 
 /**
- * Data Access Object Interface for DPoP JKT
+ * Data Access Object Interface for DPoP JKT.
  */
 public interface DPoPJKTDAO  {
 

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAO.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAO.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.dao;
+
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+/**
+ * Data Access Object Interface for DPoP JKT
+ */
+public interface DPoPJKTDAO  {
+
+    void insertDPoPJKT(String consumerKey, String codeId, String dpopJkt) throws IdentityOAuth2Exception;
+
+    String getDPoPJKTFromAuthzCode(String authzCode) throws IdentityOAuth2Exception;
+
+    String getAuthzCodeFromCodeId(String codeId) throws IdentityOAuth2Exception;
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAOImpl.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPJKTDAOImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.dao;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Implementation of DPoPJKTDAO interface.
+ */
+public class DPoPJKTDAOImpl implements DPoPJKTDAO {
+
+    private static final Log LOG = LogFactory.getLog(DPoPJKTDAOImpl.class);
+    private static TokenPersistenceProcessor hashingPersistenceProcessor;
+
+    public DPoPJKTDAOImpl() {
+
+        hashingPersistenceProcessor = new HashingPersistenceProcessor();
+    }
+    @Override
+    public void insertDPoPJKT(String consumerKey, String codeId, String dpopJkt) throws IdentityOAuth2Exception {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Persisting dpop_jkt: " + DigestUtils.sha256Hex(dpopJkt) + " for client: "
+                    + consumerKey);
+        }
+        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        PreparedStatement prepStmt = null;
+        try {
+            String sql = SQLQueries.INSERT_DPOP_JKT;
+            prepStmt = connection.prepareStatement(sql);
+            prepStmt.setString(1, codeId);
+            prepStmt.setString(2, dpopJkt);
+            prepStmt.execute();
+        } catch (SQLException e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            throw new IdentityOAuth2Exception("Error when persisting the dpop_jkt for consumer key : "
+                    + consumerKey, e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+
+    }
+
+    @Override
+    public String getDPoPJKTFromAuthzCode(String authzCode) throws IdentityOAuth2Exception {
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        PreparedStatement prepStmt = null;
+        ResultSet resultSet;
+        try {
+            String sql = SQLQueries.RETRIEVE_DPOP_JKT_BY_AUTHORIZATION_CODE;
+            prepStmt = connection.prepareStatement(sql);
+            prepStmt.setString(1, hashingPersistenceProcessor.getProcessedAuthzCode(authzCode));
+            resultSet = prepStmt.executeQuery();
+
+            if (resultSet.next()) {
+                String dpopJkt = resultSet.getString("DPOP_JKT");
+                //ensures the function returns null only when there is no entry in DB for the given authzCode
+                return (dpopJkt == null) ? "" : dpopJkt;
+            }
+            return null;
+        } catch (SQLException e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            throw new IdentityOAuth2Exception("Error when retrieving dpop_jkt for consumer key : " + authzCode, e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+    }
+
+    @Override
+    public String getAuthzCodeFromCodeId(String codeId) throws IdentityOAuth2Exception {
+        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        PreparedStatement prepStmt = null;
+        ResultSet resultSet;
+        try {
+            String sql = SQLQueries.RETRIEVE_AUTHORIZATION_CODE_BY_CODE_ID;
+            prepStmt = connection.prepareStatement(sql);
+            prepStmt.setString(1, codeId);
+            resultSet = prepStmt.executeQuery();
+
+            if (resultSet.next()) {
+                return resultSet.getString("AUTHORIZATION_CODE");
+            }
+            return null;
+        } catch (SQLException e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            throw new IdentityOAuth2Exception("Error when retrieving authorization code for code id : " + codeId, e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
@@ -61,7 +61,7 @@ public class DPoPTokenManagerDAOImpl implements DPoPTokenManagerDAO {
         try {
             String finalRefreshToken = refreshToken;
             List<TokenBinding> tokenBindingList = jdbcTemplate.executeQuery(
-                    DPoPConstants.SQLQueries.RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN,
+                    SQLQueries.RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN,
                     (resultSet, rowNumber) -> {
                         TokenBinding tokenBinding = new TokenBinding();
                         tokenBinding.setBindingType(resultSet.getString(1));

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/SQLQueries.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/SQLQueries.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.dao;
+
+/**
+ * SQL queries for DPoP related DB operations.
+ */
+public class SQLQueries {
+
+    public static final String RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN =
+            "SELECT BINDING.TOKEN_BINDING_TYPE,BINDING.TOKEN_BINDING_VALUE,BINDING.TOKEN_BINDING_REF " +
+                    "FROM IDN_OAUTH2_ACCESS_TOKEN TOKEN LEFT JOIN IDN_OAUTH2_TOKEN_BINDING BINDING ON " +
+                    "TOKEN.TOKEN_ID=BINDING.TOKEN_ID WHERE TOKEN.REFRESH_TOKEN = ? " +
+                    "AND BINDING.TOKEN_BINDING_TYPE = ?";
+
+    public static final String RETRIEVE_AUTHORIZATION_CODE_BY_CODE_ID =
+            "SELECT AUTHORIZATION_CODE FROM IDN_OAUTH2_AUTHORIZATION_CODE WHERE CODE_ID = ?";
+
+    public static final String INSERT_DPOP_JKT = "INSERT INTO IDN_OAUTH2_DPOP_JKT (CODE_ID, DPOP_JKT) VALUES (?, ?)";
+
+    public static final String RETRIEVE_DPOP_JKT_BY_AUTHORIZATION_CODE = "SELECT DPOP_JKT FROM IDN_OAUTH2_DPOP_JKT " +
+            "WHERE CODE_ID = (SELECT CODE_ID FROM IDN_OAUTH2_AUTHORIZATION_CODE WHERE AUTHORIZATION_CODE_HASH = ?)";
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.oauth.cache.OAuthCache;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dpop.cache.DPoPJKTCache;
+import org.wso2.carbon.identity.oauth2.dpop.cache.DPoPJKTCacheEntry;
+import org.wso2.carbon.identity.oauth2.dpop.cache.DPoPJKTCacheKey;
+import org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants;
+import org.wso2.carbon.identity.oauth2.dpop.dao.DPoPJKTDAOImpl;
+import org.wso2.carbon.identity.oauth2.dpop.internal.DPoPDataHolder;
+import org.wso2.carbon.identity.oauth2.dpop.validators.DPoPHeaderValidator;
+import org.wso2.carbon.identity.openidconnect.OIDCConstants;
+
+/**
+ * This class extends {@link AbstractEventHandler} and listen to oauth token related events.
+ */
+public class DPoPEventHandler extends AbstractEventHandler {
+
+    private static final Log LOG = LogFactory.getLog(DPoPEventHandler.class);
+
+    public String getName() {
+
+        return "dpopEventHandler";
+    }
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        if (StringUtils.equals(OIDCConstants.Event.POST_ISSUE_CODE, event.getEventName())) {
+
+            String codeId  = event.getEventProperties().get(OIDCConstants.Event.CODE_ID).toString();
+            String sessionDataKey = event.getEventProperties().get(OIDCConstants.Event.SESSION_DATA_KEY).toString();
+            SessionDataCacheEntry sessionDataCacheEntry = SessionDataCache.getInstance()
+                    .getValueFromCache(new SessionDataCacheKey(sessionDataKey));
+
+            if (sessionDataCacheEntry.getParamMap().containsKey(DPoPConstants.DPOP_JKT)) {
+                String dpopJkt = sessionDataCacheEntry.getParamMap().get(DPoPConstants.DPOP_JKT)[0];
+                String consumerKey = sessionDataCacheEntry.getParamMap().get(DPoPConstants.CLIENT_ID)[0];
+                try {
+                    DPoPHeaderValidator dPoPHeaderValidator = new DPoPHeaderValidator();
+                    String tokenBindingType = dPoPHeaderValidator.getApplicationBindingType(consumerKey);
+
+                    if (DPoPConstants.DPOP_TOKEN_TYPE.equals(tokenBindingType) &&
+                            DPoPDataHolder.isDPoPJKTTableEnabled()) {
+
+                        // Persist dpop_jkt in the DB
+                        DPoPJKTDAOImpl dpopJKTDAO = new DPoPJKTDAOImpl();
+                        dpopJKTDAO.insertDPoPJKT(consumerKey, codeId, dpopJkt);
+                        // Persist dpop_jkt in the cache
+                        if (OAuthCache.getInstance().isEnabled()) {
+                            DPoPJKTCacheKey dPoPJKTCacheKey = new DPoPJKTCacheKey(consumerKey,
+                                    dpopJKTDAO.getAuthzCodeFromCodeId(codeId));
+                            DPoPJKTCacheEntry dPoPJKTCacheEntry = new DPoPJKTCacheEntry(dpopJkt);
+                            DPoPJKTCache.getInstance().addToCache(dPoPJKTCacheKey, dPoPJKTCacheEntry);
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("dpop_jkt was added to the cache for client id : " +
+                                        consumerKey);
+                            }
+                        }
+                    }
+                } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+                    LOG.error("Error while persisting dpop_jkt for the client id : " + consumerKey, e);
+                    throw new IdentityEventException(DPoPConstants.INVALID_CLIENT, DPoPConstants.INVALID_CLIENT_ERROR);
+                }
+            }
+        }
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
@@ -24,7 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
-import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
@@ -75,7 +74,7 @@ public class DPoPEventHandler extends AbstractEventHandler {
                         DPoPJKTDAOImpl dpopJKTDAO = new DPoPJKTDAOImpl();
                         dpopJKTDAO.insertDPoPJKT(consumerKey, codeId, dpopJkt);
                         // Persist dpop_jkt in the cache
-                        if (OAuthCache.getInstance().isEnabled()) {
+                        if (DPoPJKTCache.getInstance().isEnabled()) {
                             DPoPJKTCacheKey dPoPJKTCacheKey = new DPoPJKTCacheKey(consumerKey,
                                     dpopJKTDAO.getAuthzCodeFromCodeId(codeId));
                             DPoPJKTCacheEntry dPoPJKTCacheEntry = new DPoPJKTCacheEntry(dpopJkt);

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/handler/DPoPEventHandler.java
@@ -85,8 +85,11 @@ public class DPoPEventHandler extends AbstractEventHandler {
                         }
                     }
                 }
-            } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-                LOG.error("Error while persisting dpop_jkt for the client id : " + consumerKey, e);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error while handling POST_ISSUE_CODE event for the consumer key : " + consumerKey, e);
+                throw new IdentityEventException(e.getErrorCode(), e.getMessage());
+            } catch (InvalidOAuthClientException e) {
+                LOG.error("Client Authentication failed for the client id : " + consumerKey, e);
                 throw new IdentityEventException(DPoPConstants.INVALID_CLIENT, DPoPConstants.INVALID_CLIENT_ERROR);
             }
         }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPDataHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPDataHolder.java
@@ -27,6 +27,7 @@ public class DPoPDataHolder {
 
     private static final DPoPDataHolder dPoPDataHolder = new DPoPDataHolder();
     private DPoPTokenManagerDAO tokenBindingTypeManagerDao;
+    private static boolean isDPoPJKTTableEnabled = false;
 
     public static DPoPDataHolder getInstance() {
 
@@ -57,5 +58,15 @@ public class DPoPDataHolder {
             DPoPTokenManagerDAO tokenBindingTypeManagerDao) {
 
         this.tokenBindingTypeManagerDao = tokenBindingTypeManagerDao;
+    }
+
+    public static boolean isDPoPJKTTableEnabled() {
+
+        return isDPoPJKTTableEnabled;
+    }
+
+    public static void setDPoPJKTTableEnabled(boolean isDPoPJKTTableEnabled) {
+
+        DPoPDataHolder.isDPoPJKTTableEnabled = isDPoPJKTTableEnabled;
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
@@ -55,8 +55,8 @@ public class DPoPServiceComponent {
     protected void activate(ComponentContext context) {
 
 
-        //TODO: Remove true and replace with the actual table check
-        boolean isAvailableTable = true; //&& IdentityDatabaseUtil.isTableExists(DPOP_JKT_TABLE_NAME);
+        //TODO: Remove false and replace with the actual table check
+        boolean isAvailableTable = false; //IdentityDatabaseUtil.isTableExists(DPOP_JKT_TABLE_NAME);
         if (LOG.isDebugEnabled()) {
             LOG.debug(DPOP_JKT_TABLE_NAME + " table is " + (isAvailableTable ? " " : "not ") + "available" +
                     "Setting isDPoPJKTTableEnabled to " + isAvailableTable);

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
@@ -24,17 +24,22 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.dpop.dao.DPoPTokenManagerDAOImpl;
 import org.wso2.carbon.identity.oauth2.dpop.handler.DPoPAuthenticationHandler;
+import org.wso2.carbon.identity.oauth2.dpop.handler.DPoPEventHandler;
 import org.wso2.carbon.identity.oauth2.dpop.introspection.dataprovider.DPoPIntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.dpop.listener.OauthDPoPInterceptorHandlerProxy;
 import org.wso2.carbon.identity.oauth2.dpop.token.binder.DPoPBasedTokenBinder;
 import org.wso2.carbon.identity.oauth2.dpop.validators.DPoPHeaderValidator;
 import org.wso2.carbon.identity.oauth2.dpop.validators.DPoPTokenValidator;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2TokenValidator;
+
+
+import static org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants.DPOP_JKT_TABLE_NAME;
 
 /**
  * OSGi service component for DPoP.
@@ -49,6 +54,15 @@ public class DPoPServiceComponent {
     @Activate
     protected void activate(ComponentContext context) {
 
+
+        //TODO: Remove true and replace with the actual table check
+        boolean isAvailableTable = true; //&& IdentityDatabaseUtil.isTableExists(DPOP_JKT_TABLE_NAME);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(DPOP_JKT_TABLE_NAME + " table is " + (isAvailableTable ? " " : "not ") + "available" +
+                    "Setting isDPoPJKTTableEnabled to " + isAvailableTable);
+        }
+        DPoPDataHolder.setDPoPJKTTableEnabled(isAvailableTable);
+
         DPoPDataHolder.getInstance().setTokenBindingTypeManagerDao(new DPoPTokenManagerDAOImpl());
         context.getBundleContext().registerService(TokenBinderInfo.class.getName(),
                 new DPoPBasedTokenBinder(), null);
@@ -60,6 +74,8 @@ public class DPoPServiceComponent {
                 new DPoPIntrospectionDataProvider(), null);
         context.getBundleContext().registerService(OAuth2TokenValidator.class.getName(),
                 new DPoPTokenValidator(), null);
+        context.getBundleContext().registerService(AbstractEventHandler.class.getName(),
+                new DPoPEventHandler(), null);
         if (LOG.isDebugEnabled()) {
             LOG.debug("DPoPService is activated.");
         }


### PR DESCRIPTION
#parent issue : https://github.com/wso2/product-is/issues/16606

## Purpose

Binding the authorization code issued, to the client's proof-of-possession key can enable end-to-end binding of the entire authorization flow.The specification defines the `dpop_jkt` **authorization request parameter** for this purpose. The value of the` dpop_jkt` authorization request parameter is the JWK Thumbprint of the proof-of-possession public key using the SHA-256 hash function, which is the same value as used for the `jkt` confirmation method in dpop bound access tokens.

When a token request is received, the authorization server computes the JWK Thumbprint of the proof-of-possession public key in the DPoP proof and verifies that it matches the `dpop_jkt` parameter value in the authorization request. If they do not match, it MUST reject the request.

Use of the `dpop_jkt` authorization request parameter is **OPTIONAL** and the authorization code binding will be validated during the token request only if this parameter is presented with the authorization code request.

Implementation of this mechanism requires : 
- [ ]  Detect `dpop_jkt` parameter in authorization requests.
- [ ] If present, persist the value.
- [ ] Retrieve the persisted value at the time of token request.
- [ ] compare the retrieved value with the hash calculated from the JWK value extracted from the DPoP proof.

this PR contains an event handler which is listening for events of type `POST_ISSUE_CODE` will search for `dpop_jkt` parameter in the authorization request parameters.

If the `dpop_jkt` is present in authorization request parameters & the application is using DPoP token binding type, then the event handler persists the value along with the `code_id`of the authorization code issued for that request.This persistence involves

1. Cache persistance in `DPoPJKTCache` (implemented in this pr).
2. DB persistance in `IDN_OAUTH2_DPOP_JKT` Table.

At the time of deployment of the DPoP OSGI bundle, the availability of the `IDN_OAUTH2_DPOP_JKT` will be checked in the DB and that information will be stored in the bundles' data holder as a boolean.

Authorization Code Binding will only be enabled if the table is available in the DB (i.e this won't work only with cache).
This check ensures that customers will still be able to use DPoP without the need of a DB migration but, without authorization code binding feature.




