### PR TITLE
fix javadoc plugin issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -377,7 +379,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration> <!-- add this to disable checking -->
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Purpose
#### Fix for Jenkins build failure due to a javadoc  plugin issue.
![image](https://github.com/wso2-extensions/identity-oauth-dpop/assets/110591829/8cf40306-ca76-4987-bc12-aec33f4f1148)

