### PR TITLE
DPoP Authorization Code Binding For PAR Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ properties.skip_dpop_validation_in_revoke = "true"
 
 [[event_handler]]
 name= "dpopEventHandler"
-subscriptions =["POST_ISSUE_CODE"]
+subscriptions =["POST_ISSUE_CODE","PRE_HANDLE_PAR_REQUEST"]
 
 [[oauth.custom_token_validator]]
 type = "dpop"

--- a/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>org.wso2.carbon.identity.oauth.common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth.par</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/constant/DPoPConstants.java
@@ -25,6 +25,7 @@ public class DPoPConstants {
 
     public static final String VALIDITY_PERIOD = "header_validity_period";
     public static final int DEFAULT_HEADER_VALIDITY = 60000;
+    public static final String DPOP_EVENT_HANDLER_NAME = "dpopEventHandler";
     public static final String DPOP_ISSUED_AT = "iat";
     public static final String DPOP_HTTP_URI = "htu";
     public static final String DPOP_HTTP_METHOD = "htm";
@@ -39,6 +40,7 @@ public class DPoPConstants {
     public static final String ECDSA_ENCRYPTION = "EC";
     public static final String RSA_ENCRYPTION = "RSA";
     public static final String HTTP_METHOD = "httpMethod";
+    public static final String HTTP_POST = "POST";
     public static final String HTTP_URL = "httpUrl";
     public static final String JTI = "jti";
     public static final String OAUTH_DPOP_HEADER = "DPoP";

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+                <artifactId>org.wso2.carbon.identity.oauth.par</artifactId>
+                <version>${identity.inbound.auth.oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth</artifactId>
                 <version>${identity.inbound.auth.oauth.version}</version>
             </dependency>
@@ -403,7 +408,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>6.11.188</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.35</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>5.25.383</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>7.0.35</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.67</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>5.25.383</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
This PR extends the functionality of `DPoPEventHandler` class to handle events of type `PRE_HANDLE_PAR_REQUEST`.

## Approach

If a DPoP headers is present in a PAR request, `DPoPEventHandler` will validate the header and if the validation failed,the request will be rejected. Uppon successful validation, the event handler will check for the presence of `dpop_jkt` request parameter in the PAR request. 
- If `dpop_jkt` request parameter  is also present in the PAR request, the JWK thumbprint of the  DPoP header will be compared with value of that parameter and if the comparison failed, the request will be rejected.
- Alternatively, if the dpop_jkt request parameter is absent in the request, the thumbprint value derived from the validated DPoP proof header will be appended to the request parameter set with the key dpop_jkt. This addition ensures the continuation of the authorization code binding mechanism as if the dpop_jkt parameter had been initially included in the request.


