### PR TITLE
Support for tenant qualified URLs

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
@@ -165,7 +165,7 @@ public class DPoPHeaderValidator {
             HttpServletRequest request = tokenReqDTO.getHttpServletRequestWrapper();
             String httpMethod = request.getMethod();
             String httpURI = request.getRequestURI();
-            String httpURL = OAuth2Util.buildServiceUrl(httpURI, null);
+            String httpURL = OAuth2Util.buildServiceUrl(httpURI, null, null);
             
             if (isValidDPoPProof(httpMethod, httpURL, dPoPProof)) {
                 String thumbprint = Utils.getThumbprintOfKeyFromDpopProof(dPoPProof);

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
@@ -164,7 +164,9 @@ public class DPoPHeaderValidator {
         try {
             HttpServletRequest request = tokenReqDTO.getHttpServletRequestWrapper();
             String httpMethod = request.getMethod();
-            String httpURL = request.getRequestURL().toString();
+            String httpURI = request.getRequestURI();
+            String httpURL = OAuth2Util.buildServiceUrl(httpURI, null);
+            
             if (isValidDPoPProof(httpMethod, httpURL, dPoPProof)) {
                 String thumbprint = Utils.getThumbprintOfKeyFromDpopProof(dPoPProof);
                 if (StringUtils.isNotBlank(thumbprint)) {

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
@@ -308,7 +308,8 @@ public class DPoPHeaderValidatorTest {
         when(oAuth2AccessTokenReqDTO.getHttpServletRequestWrapper()).thenReturn(httpServletRequest);
         when(httpServletRequest.getMethod()).thenReturn(DUMMY_HTTP_METHOD);
         when(httpServletRequest.getRequestURI()).thenReturn(DUMMY_HTTP_URL);
-        when(OAuth2Util.buildServiceUrl(DUMMY_HTTP_URL, null)).thenReturn(DUMMY_HTTP_URL);
+        when(OAuth2Util.buildServiceUrl(DUMMY_HTTP_URL, null, null))
+                .thenReturn(DUMMY_HTTP_URL);
         try {
             assertTrue(dPoPHeaderValidator.isValidDPoP(dPoPProof, oAuth2AccessTokenReqDTO, tokReqMsgCtx));
         } catch (IdentityOAuth2Exception e) {

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
@@ -53,6 +53,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequestWrapper;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -73,14 +74,9 @@ import static org.wso2.carbon.identity.oauth2.dpop.util.DPoPTestConstants.DUMMY_
 
 public class DPoPHeaderValidatorTest {
 
-    @Mock
     private OAuthTokenReqMessageContext tokReqMsgCtx;
 
-    @Mock
     private OAuth2AccessTokenReqDTO oAuth2AccessTokenReqDTO;
-
-    @Mock
-    private HttpServletRequestWrapper httpServletRequest;
 
     @Mock
     private Properties properties;
@@ -118,6 +114,8 @@ public class DPoPHeaderValidatorTest {
         mockIdentityUtil.when(() -> IdentityUtil.readEventListenerProperty(anyString(), anyString()))
                 .thenReturn(identityEventListenerConfig);
         when(identityEventListenerConfig.getProperties()).thenReturn(properties);
+        oAuth2AccessTokenReqDTO = new OAuth2AccessTokenReqDTO();
+        tokReqMsgCtx = createTokenReqMessageContext();
     }
 
     @AfterMethod
@@ -143,8 +141,7 @@ public class DPoPHeaderValidatorTest {
     public void testGetDPoPHeader(Object httpRequestHeaders, String expectedResult) {
 
         try {
-            when(tokReqMsgCtx.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
-            when(oAuth2AccessTokenReqDTO.getHttpRequestHeaders()).thenReturn((HttpRequestHeader[]) httpRequestHeaders);
+            oAuth2AccessTokenReqDTO.setHttpRequestHeaders((HttpRequestHeader[]) httpRequestHeaders);
             String dPoPHeader = dPoPHeaderValidator.getDPoPHeader(tokReqMsgCtx);
             assertEquals(dPoPHeader, expectedResult);
         } catch (IdentityOAuth2ClientException e) {
@@ -304,10 +301,6 @@ public class DPoPHeaderValidatorTest {
 
     @Test(dataProvider = "isValidDPoPTestData")
     public void testIsValidDPoP(String dPoPProof) {
-
-        when(oAuth2AccessTokenReqDTO.getHttpServletRequestWrapper()).thenReturn(httpServletRequest);
-        when(httpServletRequest.getMethod()).thenReturn(DUMMY_HTTP_METHOD);
-        when(httpServletRequest.getRequestURI()).thenReturn(DUMMY_HTTP_URL);
         when(OAuth2Util.buildServiceUrl(DUMMY_HTTP_URL, null, null))
                 .thenReturn(DUMMY_HTTP_URL);
         try {
@@ -316,5 +309,18 @@ public class DPoPHeaderValidatorTest {
             assertEquals(e.getErrorCode(), INVALID_DPOP_PROOF);
             assertEquals(e.getMessage(), INVALID_DPOP_ERROR);
         }
+    }
+
+    private OAuthTokenReqMessageContext createTokenReqMessageContext() {
+
+        OAuthTokenReqMessageContext tokenReqMessageContext =
+                new OAuthTokenReqMessageContext(oAuth2AccessTokenReqDTO);
+
+        HttpServletRequestWrapper httpServletRequestWrapper = mock(HttpServletRequestWrapper.class);
+        when(httpServletRequestWrapper.getMethod()).thenReturn(DUMMY_HTTP_METHOD);
+        when(httpServletRequestWrapper.getRequestURI()).thenReturn(DUMMY_HTTP_URL);
+        oAuth2AccessTokenReqDTO.setHttpServletRequestWrapper(httpServletRequestWrapper);
+
+        return tokenReqMessageContext;
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidatorTest.java
@@ -307,7 +307,8 @@ public class DPoPHeaderValidatorTest {
 
         when(oAuth2AccessTokenReqDTO.getHttpServletRequestWrapper()).thenReturn(httpServletRequest);
         when(httpServletRequest.getMethod()).thenReturn(DUMMY_HTTP_METHOD);
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer(DUMMY_HTTP_URL));
+        when(httpServletRequest.getRequestURI()).thenReturn(DUMMY_HTTP_URL);
+        when(OAuth2Util.buildServiceUrl(DUMMY_HTTP_URL, null)).thenReturn(DUMMY_HTTP_URL);
         try {
             assertTrue(dPoPHeaderValidator.isValidDPoP(dPoPProof, oAuth2AccessTokenReqDTO, tokReqMsgCtx));
         } catch (IdentityOAuth2Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>7.0.67</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.268</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>5.25.383</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
Currently in DPoP no support was given for tenanted url's such as `https://localhost:9443/t/abc.com/oauth2/token` which resulted in requests with such URL's to get an `invalid_dpop_proof` error. The issue was due to the URL in the request object not having the tenant domain. 

This solution correctly constructs the URL in the request with the tenant domain. 

<img width="989" alt="Screenshot 2025-03-24 at 14 26 05" src="https://github.com/user-attachments/assets/ab57a46c-1976-4836-9044-dc4e3b2789d9" />



## Related Issue 
- https://github.com/wso2/product-is/issues/20428