### PR TITLE
Use refresh token hash to retrieve token binding reference

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAO.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,5 +33,5 @@ public interface DPoPTokenManagerDAO {
      * @return TokenBinding from the refresh token.
      * @throws IdentityOAuth2Exception If an error occurs while retrieving the binding type.
      */
-    TokenBinding getTokenBinding(String refreshToken, boolean isHashedToken) throws IdentityOAuth2Exception;
+    TokenBinding getTokenBinding(String refreshToken) throws IdentityOAuth2Exception;
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAO.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAO.java
@@ -33,5 +33,5 @@ public interface DPoPTokenManagerDAO {
      * @return TokenBinding from the refresh token.
      * @throws IdentityOAuth2Exception If an error occurs while retrieving the binding type.
      */
-    TokenBinding getTokenBinding(String refreshToken) throws IdentityOAuth2Exception;
+    TokenBinding getTokenBindingUsingHash(String refreshToken) throws IdentityOAuth2Exception;
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class DPoPTokenManagerDAOImpl implements DPoPTokenManagerDAO {
 
     @Override
-    public TokenBinding getTokenBinding(String refreshToken)
+    public TokenBinding getTokenBindingUsingHash(String refreshToken)
             throws IdentityOAuth2Exception {
 
         JdbcTemplate jdbcTemplate = Utils.getNewTemplate();

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/DPoPTokenManagerDAOImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -34,34 +34,19 @@ import java.util.List;
  */
 public class DPoPTokenManagerDAOImpl implements DPoPTokenManagerDAO {
 
-    private static TokenPersistenceProcessor hashingPersistenceProcessor;
-
-    public DPoPTokenManagerDAOImpl() {
-
-        hashingPersistenceProcessor = new HashingPersistenceProcessor();
-    }
-
     @Override
-    public TokenBinding getTokenBinding(String refreshToken, boolean isTokenHashingEnabled)
-            throws IdentityOAuth2Exception {
-
-        if (isTokenHashingEnabled) {
-            return getBindingFromRefreshToken(refreshToken, true);
-        }
-        return getBindingFromRefreshToken(refreshToken, false);
-    }
-
-    private TokenBinding getBindingFromRefreshToken(String refreshToken, boolean isTokenHashingEnabled)
+    public TokenBinding getTokenBinding(String refreshToken)
             throws IdentityOAuth2Exception {
 
         JdbcTemplate jdbcTemplate = Utils.getNewTemplate();
-        if (isTokenHashingEnabled) {
-            refreshToken = hashingPersistenceProcessor.getProcessedRefreshToken(refreshToken);
-        }
+
+        TokenPersistenceProcessor hashingPersistenceProcessor = new HashingPersistenceProcessor();
+        refreshToken = hashingPersistenceProcessor.getProcessedRefreshToken(refreshToken);
+
         try {
             String finalRefreshToken = refreshToken;
             List<TokenBinding> tokenBindingList = jdbcTemplate.executeQuery(
-                    SQLQueries.RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN,
+                    SQLQueries.RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN_HASH,
                     (resultSet, rowNumber) -> {
                         TokenBinding tokenBinding = new TokenBinding();
                         tokenBinding.setBindingType(resultSet.getString(1));

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/SQLQueries.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/dao/SQLQueries.java
@@ -23,10 +23,10 @@ package org.wso2.carbon.identity.oauth2.dpop.dao;
  */
 public class SQLQueries {
 
-    public static final String RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN =
+    public static final String RETRIEVE_TOKEN_BINDING_BY_REFRESH_TOKEN_HASH =
             "SELECT BINDING.TOKEN_BINDING_TYPE,BINDING.TOKEN_BINDING_VALUE,BINDING.TOKEN_BINDING_REF " +
                     "FROM IDN_OAUTH2_ACCESS_TOKEN TOKEN LEFT JOIN IDN_OAUTH2_TOKEN_BINDING BINDING ON " +
-                    "TOKEN.TOKEN_ID=BINDING.TOKEN_ID WHERE TOKEN.REFRESH_TOKEN = ? " +
+                    "TOKEN.TOKEN_ID=BINDING.TOKEN_ID WHERE TOKEN.REFRESH_TOKEN_HASH = ? " +
                     "AND BINDING.TOKEN_BINDING_TYPE = ?";
 
     public static final String RETRIEVE_AUTHORIZATION_CODE_BY_CODE_ID =

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/OauthDPoPInterceptorHandlerProxy.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/OauthDPoPInterceptorHandlerProxy.java
@@ -107,7 +107,8 @@ public class OauthDPoPInterceptorHandlerProxy extends AbstractOAuthEventIntercep
         }
         try {
             String tokenBindingType = dPoPHeaderValidator.getApplicationBindingType(tokenReqDTO.getClientId());
-            TokenBinding tokenBinding = tokenBindingTypeManagerDao.getTokenBinding(tokenReqDTO.getRefreshToken());
+            TokenBinding tokenBinding = tokenBindingTypeManagerDao
+                    .getTokenBindingUsingHash(tokenReqDTO.getRefreshToken());
             if (tokenBinding != null) {
                 if (!DPoPConstants.DPOP_TOKEN_TYPE.equals(tokenBindingType)) {
                     if (LOG.isDebugEnabled()) {

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/OauthDPoPInterceptorHandlerProxy.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/OauthDPoPInterceptorHandlerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,7 +36,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.Map;
 
@@ -108,8 +107,7 @@ public class OauthDPoPInterceptorHandlerProxy extends AbstractOAuthEventIntercep
         }
         try {
             String tokenBindingType = dPoPHeaderValidator.getApplicationBindingType(tokenReqDTO.getClientId());
-            TokenBinding tokenBinding = tokenBindingTypeManagerDao.getTokenBinding(tokenReqDTO.getRefreshToken(),
-                            OAuth2Util.isHashEnabled());
+            TokenBinding tokenBinding = tokenBindingTypeManagerDao.getTokenBinding(tokenReqDTO.getRefreshToken());
             if (tokenBinding != null) {
                 if (!DPoPConstants.DPOP_TOKEN_TYPE.equals(tokenBindingType)) {
                     if (LOG.isDebugEnabled()) {

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/token/binder/DPoPBasedTokenBinder.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/token/binder/DPoPBasedTokenBinder.java
@@ -132,7 +132,7 @@ public class DPoPBasedTokenBinder extends AbstractTokenBinder {
         String refreshToken = oAuth2AccessTokenReqDTO.getRefreshToken();
         try {
             TokenBinding tokenBinding =
-                    tokenBindingTypeManagerDao.getTokenBinding(refreshToken);
+                    tokenBindingTypeManagerDao.getTokenBindingUsingHash(refreshToken);
 
             if (tokenBinding != null && DPoPConstants.OAUTH_DPOP_HEADER.equals(tokenBinding.getBindingType())) {
                 return bindingReference.equalsIgnoreCase(tokenBinding.getBindingReference());

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/token/binder/DPoPBasedTokenBinder.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/token/binder/DPoPBasedTokenBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,7 +36,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.AbstractTokenBinder;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -133,7 +132,7 @@ public class DPoPBasedTokenBinder extends AbstractTokenBinder {
         String refreshToken = oAuth2AccessTokenReqDTO.getRefreshToken();
         try {
             TokenBinding tokenBinding =
-                    tokenBindingTypeManagerDao.getTokenBinding(refreshToken, OAuth2Util.isHashEnabled());
+                    tokenBindingTypeManagerDao.getTokenBinding(refreshToken);
 
             if (tokenBinding != null && DPoPConstants.OAUTH_DPOP_HEADER.equals(tokenBinding.getBindingType())) {
                 return bindingReference.equalsIgnoreCase(tokenBinding.getBindingReference());


### PR DESCRIPTION
## Purpose
This PR updates the token binding retrieval logic in the refresh token grant flow.
Instead of matching against the encrypted refresh token, the refresh token hash is computed and used to query the database. 

## Related Issues
- https://github.com/wso2/product-is/issues/23802
- https://github.com/wso2/product-is/issues/20428

 ## Screenshots
 ### With enabled EncryptionDecryptionProcessor 
 
 
<img width="988" alt="Screenshot 2025-04-17 at 10 32 10" src="https://github.com/user-attachments/assets/f42d033c-7e7f-476f-9ddf-99d2376ac122" />

 
 ### With enabled PlainTextProcessor
 
 
<img width="1011" alt="Screenshot 2025-04-17 at 10 45 35" src="https://github.com/user-attachments/assets/1e0d6a55-61fc-4277-84c6-4251bb3aefe2" />
