### PR TITLE
Adding DPoP processing and validation for /authorize-challenge endpoint

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/pom.xml
@@ -140,6 +140,8 @@
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.authz.*;
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
+                            org.wso2.carbon.identity.oauth2.authzChallenge.*;
+                            version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.token.*;
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth2.dto;

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
@@ -33,10 +33,12 @@ import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
+import org.wso2.carbon.identity.oauth2.authzChallenge.event.AuthzChallengeInterceptor;
 import org.wso2.carbon.identity.oauth2.dpop.dao.DPoPTokenManagerDAOImpl;
 import org.wso2.carbon.identity.oauth2.dpop.handler.DPoPAuthenticationHandler;
 import org.wso2.carbon.identity.oauth2.dpop.handler.DPoPEventHandler;
 import org.wso2.carbon.identity.oauth2.dpop.introspection.dataprovider.DPoPIntrospectionDataProvider;
+import org.wso2.carbon.identity.oauth2.dpop.listener.AuthzChallengeDPoPInterceptorHandlerProxy;
 import org.wso2.carbon.identity.oauth2.dpop.listener.OauthDPoPInterceptorHandlerProxy;
 import org.wso2.carbon.identity.oauth2.dpop.token.binder.DPoPBasedTokenBinder;
 import org.wso2.carbon.identity.oauth2.dpop.validators.DPoPHeaderValidator;
@@ -80,6 +82,8 @@ public class DPoPServiceComponent {
                     new DPoPTokenValidator(), null);
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(),
                     new DPoPEventHandler(), null);
+            context.getBundleContext().registerService(AuthzChallengeInterceptor.class.getName(),
+                    new AuthzChallengeDPoPInterceptorHandlerProxy(new DPoPHeaderValidator()), null);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("DPoPService is activated.");
             }
@@ -92,7 +96,7 @@ public class DPoPServiceComponent {
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Unset Identity core Intialized Event Service.");
+            LOG.debug("Unset Identity core Initialized Event Service.");
         }
     }
 
@@ -107,7 +111,7 @@ public class DPoPServiceComponent {
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Set Identity core Intialized Event Service.");
+            LOG.debug("Set Identity core Initialized Event Service.");
         }
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/AuthzChallengeDPoPInterceptorHandlerProxy.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/AuthzChallengeDPoPInterceptorHandlerProxy.java
@@ -39,6 +39,7 @@ public class AuthzChallengeDPoPInterceptorHandlerProxy extends AbstractIdentityH
     private final DPoPHeaderValidator dPoPHeaderValidator;
 
     public AuthzChallengeDPoPInterceptorHandlerProxy(DPoPHeaderValidator dPoPHeaderValidator) {
+
         this.dPoPHeaderValidator = dPoPHeaderValidator;
     }
 
@@ -51,6 +52,7 @@ public class AuthzChallengeDPoPInterceptorHandlerProxy extends AbstractIdentityH
      */
     @Override
     public String handleAuthzChallengeReq(OAuth2AuthzChallengeReqDTO requestDTO) throws IdentityOAuth2Exception {
+
         try {
             String dPoPProof = dPoPHeaderValidator.extractDPoPHeader(requestDTO.getHttpRequestHeaders());
 

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/AuthzChallengeDPoPInterceptorHandlerProxy.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/listener/AuthzChallengeDPoPInterceptorHandlerProxy.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.dpop.listener;
+
+import java.text.ParseException;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.oauth2.authzChallenge.event.AuthzChallengeInterceptor;
+import org.wso2.carbon.identity.oauth2.dpop.util.Utils;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthzChallengeReqDTO;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants;
+import org.wso2.carbon.identity.oauth2.dpop.validators.DPoPHeaderValidator;
+
+public class AuthzChallengeDPoPInterceptorHandlerProxy extends AbstractIdentityHandler implements
+        AuthzChallengeInterceptor {
+
+    private static final Log LOG = LogFactory.getLog(AuthzChallengeDPoPInterceptorHandlerProxy.class);
+    private final DPoPHeaderValidator dPoPHeaderValidator;
+
+    public AuthzChallengeDPoPInterceptorHandlerProxy(DPoPHeaderValidator dPoPHeaderValidator) {
+        this.dPoPHeaderValidator = dPoPHeaderValidator;
+    }
+
+    /**
+     * Handles the authorize-challenge request by validating the DPoP header.
+     *
+     * @param requestDTO authorize-challenge request DTO
+     * @return thumbprint of the key extracted from the DPoP proof
+     * @throws IdentityOAuth2Exception error during DPoP validation or parsing
+     */
+    @Override
+    public String handleAuthzChallengeReq(OAuth2AuthzChallengeReqDTO requestDTO) throws IdentityOAuth2Exception {
+        try {
+            String dPoPProof = dPoPHeaderValidator.extractDPoPHeader(requestDTO.getHttpRequestHeaders());
+
+            if (StringUtils.isBlank(dPoPProof)) {
+                throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF,
+                        "DPoP header is required.");
+            }
+
+            String consumerKey = requestDTO.getClientId();
+            HttpServletRequest request = requestDTO.getHttpServletRequestWrapper();
+            String httpMethod = request.getMethod();
+            String httpURL = request.getRequestURL().toString();
+            if (!dPoPHeaderValidator.isValidDPoPProof(httpMethod, httpURL, dPoPProof)){
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("DPoP proof validation failed, Application ID: %s.", consumerKey));
+                }
+                throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF,
+                        DPoPConstants.INVALID_DPOP_ERROR);
+            }
+            return Utils.getThumbprintOfKeyFromDpopProof(dPoPProof);
+        } catch (ParseException e) {
+            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF,
+                    "Error parsing DPoP proof header." , e);
+        }
+    }
+}

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -79,25 +79,22 @@ public class DPoPHeaderValidator {
     }
 
     public String extractDPoPHeader(HttpRequestHeader[] httpRequestHeaders) throws IdentityOAuth2ClientException {
+
         if (httpRequestHeaders != null) {
             for (HttpRequestHeader header : httpRequestHeaders) {
                 if (header != null && DPoPConstants.OAUTH_DPOP_HEADER.equalsIgnoreCase(header.getName())) {
-                    if (ArrayUtils.isNotEmpty(header.getValue())) {
-                        if (header.getValue().length > 1) {
-                            String[] values = header.getValue();
+                    String[] values = header.getValue();
 
-                            if (ArrayUtils.isNotEmpty(values)) {
-                                if (values.length > 1) {
-                                    String error = "Exception occurred while extracting the DPoP proof header: " +
-                                            "Request contains multiple DPoP headers.";
-                                    LOG.error(error);
-                                    throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, error);
-                                }
-                                return values[0];
-                            }
-                            return null;
+                    if (ArrayUtils.isNotEmpty(values)) {
+                        if (values.length > 1) {
+                            String error = "Exception occurred while extracting the DPoP proof header: " +
+                                    "Request contains multiple DPoP headers.";
+                            LOG.error(error);
+                            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, error);
                         }
+                        return values[0];
                     }
+                    return null;
                 }
             }
         }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/validators/DPoPHeaderValidator.java
@@ -75,19 +75,29 @@ public class DPoPHeaderValidator {
     public String getDPoPHeader(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2ClientException {
 
         HttpRequestHeader[] httpRequestHeaders = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getHttpRequestHeaders();
+        return extractDPoPHeader(httpRequestHeaders);
+    }
+
+    public String extractDPoPHeader(HttpRequestHeader[] httpRequestHeaders) throws IdentityOAuth2ClientException {
         if (httpRequestHeaders != null) {
             for (HttpRequestHeader header : httpRequestHeaders) {
                 if (header != null && DPoPConstants.OAUTH_DPOP_HEADER.equalsIgnoreCase(header.getName())) {
                     if (ArrayUtils.isNotEmpty(header.getValue())) {
                         if (header.getValue().length > 1) {
-                            String error = "Exception occurred while extracting the DPoP proof header: " +
-                                    "Request contains multiple DPoP headers.";
-                            LOG.error(error);
-                            throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, error);
+                            String[] values = header.getValue();
+
+                            if (ArrayUtils.isNotEmpty(values)) {
+                                if (values.length > 1) {
+                                    String error = "Exception occurred while extracting the DPoP proof header: " +
+                                            "Request contains multiple DPoP headers.";
+                                    LOG.error(error);
+                                    throw new IdentityOAuth2ClientException(DPoPConstants.INVALID_DPOP_PROOF, error);
+                                }
+                                return values[0];
+                            }
+                            return null;
                         }
-                        return header.getValue()[0];
                     }
-                    return null;
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <carbon.identity.version>5.20.322</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>7.0.67</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.259</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>5.25.383</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
> Adding the necessary DPoP header validations and processing required for auth_session device binding in /authorize-challenge endpoint.

## Goals
> Adding a new listener ("AuthzChallengeDPoPInterceptorHandlerProxy") to validate the DPoP header and extract the thumbprint from request DTO.

### Related Issues
- https://github.com/wso2/product-is/issues/21696
