### PR TITLE
Get token provider from Oauth

### DIFF
--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPDataHolder.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPDataHolder.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.dpop.internal;
 
-import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultTokenProvider;
-import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.dpop.dao.DPoPTokenManagerDAO;
 
 /**
@@ -30,7 +28,6 @@ public class DPoPDataHolder {
     private static final DPoPDataHolder dPoPDataHolder = new DPoPDataHolder();
     private DPoPTokenManagerDAO tokenBindingTypeManagerDao;
     private static boolean isDPoPJKTTableEnabled = false;
-    private TokenProvider tokenProvider;
 
     public static DPoPDataHolder getInstance() {
 
@@ -71,28 +68,5 @@ public class DPoPDataHolder {
     public static void setDPoPJKTTableEnabled(boolean isDPoPJKTTableEnabled) {
 
         DPoPDataHolder.isDPoPJKTTableEnabled = isDPoPJKTTableEnabled;
-    }
-
-    /**
-     * Get token provider.
-     *
-     * @return TokenProvider
-     */
-    public TokenProvider getTokenProvider() {
-
-        if (tokenProvider == null) {
-            tokenProvider = new DefaultTokenProvider();
-        }
-        return tokenProvider;
-    }
-
-    /**
-     * Set token provider.
-     *
-     * @param tokenProvider TokenProvider
-     */
-    public void setTokenProvider(TokenProvider tokenProvider) {
-
-        this.tokenProvider = tokenProvider;
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/internal/DPoPServiceComponent.java
@@ -35,7 +35,6 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
-import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.dpop.dao.DPoPTokenManagerDAOImpl;
 import org.wso2.carbon.identity.oauth2.dpop.handler.DPoPAuthenticationHandler;
@@ -59,7 +58,6 @@ import static org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants.DPOP_J
 public class DPoPServiceComponent {
 
     private static final Log LOG = LogFactory.getLog(DPoPServiceComponent.class);
-    private TokenProvider tokenProvider;
 
     @Activate
     protected void activate(ComponentContext context) {
@@ -121,28 +119,5 @@ public class DPoPServiceComponent {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Set Identity core Intialized Event Service.");
         }
-    }
-
-    @Reference(
-            name = "token.provider",
-            service = TokenProvider.class,
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetTokenProvider"
-    )
-    protected void setTokenProvider(TokenProvider tokenProvider) {
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Setting token provider.");
-        }
-        DPoPDataHolder.getInstance().setTokenProvider(tokenProvider);
-    }
-
-    protected void unsetTokenProvider(TokenProvider tokenProvider) {
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting token provider.");
-        }
-        DPoPDataHolder.getInstance().setTokenProvider(null);
     }
 }

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProvider.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProvider.java
@@ -24,10 +24,10 @@ import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants;
-import org.wso2.carbon.identity.oauth2.dpop.internal.DPoPDataHolder;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,12 +49,11 @@ public class DPoPIntrospectionDataProvider extends AbstractIdentityHandler imple
 
         if (isEnabled()) {
            if (StringUtils.equals(TOKEN_TYPE_NAME, oAuth2IntrospectionResponseDTO.getTokenType())) {
-               accessTokenDO = DPoPDataHolder.getInstance().getTokenProvider().
-                       getVerifiedRefreshToken(oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier());
+               accessTokenDO = OAuth2Util.getTokenProvider().getVerifiedRefreshToken(
+                       oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier());
            } else {
-               accessTokenDO = DPoPDataHolder.getInstance().getTokenProvider().
-                       getVerifiedAccessToken(oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier(),
-                               false);
+               accessTokenDO = OAuth2Util.getTokenProvider().getVerifiedAccessToken(
+                       oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier(), false);
            }
 
            if (accessTokenDO.getTokenBinding() != null &&

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProvider.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/main/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProvider.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.identity.oauth2.dpop.internal.DPoPDataHolder;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,9 +52,9 @@ public class DPoPIntrospectionDataProvider extends AbstractIdentityHandler imple
                accessTokenDO = DPoPDataHolder.getInstance().getTokenProvider().
                        getVerifiedRefreshToken(oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier());
            } else {
-               accessTokenDO = OAuth2Util
-                       .findAccessToken(oAuth2TokenValidationRequestDTO.getAccessToken()
-                               .getIdentifier(), false);
+               accessTokenDO = DPoPDataHolder.getInstance().getTokenProvider().
+                       getVerifiedAccessToken(oAuth2TokenValidationRequestDTO.getAccessToken().getIdentifier(),
+                               false);
            }
 
            if (accessTokenDO.getTokenBinding() != null &&

--- a/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProviderTest.java
+++ b/component/org.wso2.carbon.identity.oauth2.dpop/src/test/java/org/wso2/carbon/identity/oauth2/dpop/introspection/dataprovider/DPoPIntrospectionDataProviderTest.java
@@ -24,11 +24,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dpop.constant.DPoPConstants;
-import org.wso2.carbon.identity.oauth2.dpop.internal.DPoPDataHolder;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
@@ -37,8 +35,8 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -57,9 +55,6 @@ public class DPoPIntrospectionDataProviderTest {
 
     @Mock
     private TokenProvider tokenProvider;
-
-    @Mock
-    private OAuthServerConfiguration mockedOAuthServerConfiguration;
 
     @Mock
     private OAuth2TokenValidationRequestDTO tokenValidationRequestDTO;
@@ -93,19 +88,20 @@ public class DPoPIntrospectionDataProviderTest {
 
         when(tokenBinding.getBindingType()).thenReturn(DPoPConstants.DPOP_TOKEN_TYPE);
         when(tokenBinding.getBindingValue()).thenReturn("jwk-thumbprint");
-        accessTokenDO.setTokenBinding(tokenBinding);
-
         when(accessTokenDO.getTokenBinding()).thenReturn(tokenBinding);
         when(tokenProvider.getVerifiedRefreshToken("accessTokenId")).thenReturn(accessTokenDO);
-        DPoPDataHolder.getInstance().setTokenProvider(tokenProvider);
 
-        this.introspectionResponseDTO.setTokenType(TOKEN_TYPE_NAME);
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            oAuth2Util.when(OAuth2Util::getTokenProvider).thenReturn(tokenProvider);
 
-        Map<String, Object> result = introspectionDataProvider.getIntrospectionData(
-                tokenValidationRequestDTO, introspectionResponseDTO);
+            this.introspectionResponseDTO.setTokenType(TOKEN_TYPE_NAME);
 
-        Assert.assertEquals(result.get(DPoPConstants.TOKEN_TYPE), DPoPConstants.DPOP_TOKEN_TYPE);
-        Assert.assertNotNull(result.get(DPoPConstants.CNF));
+            Map<String, Object> result = introspectionDataProvider.getIntrospectionData(
+                    tokenValidationRequestDTO, introspectionResponseDTO);
+
+            Assert.assertEquals(result.get(DPoPConstants.TOKEN_TYPE), DPoPConstants.DPOP_TOKEN_TYPE);
+            Assert.assertNotNull(result.get(DPoPConstants.CNF));
+        }
     }
 
     @Test
@@ -117,16 +113,10 @@ public class DPoPIntrospectionDataProviderTest {
 
         when(accessTokenDO.getTokenBinding()).thenReturn(tokenBinding);
 
-        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
-                        OAuthServerConfiguration.class);
-                MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
 
-            mockedOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
-            oAuthServerConfiguration.when(
-                    OAuthServerConfiguration::getInstance).thenReturn(mockedOAuthServerConfiguration);
-            when(mockedOAuthServerConfiguration.getTimeStampSkewInSeconds()).thenReturn(360L);
-
-            oAuth2Util.when(() -> OAuth2Util.findAccessToken(any(), anyBoolean())).thenReturn(accessTokenDO);
+            when(tokenProvider.getVerifiedAccessToken(anyString(), anyBoolean())).thenReturn(accessTokenDO);
+            oAuth2Util.when(OAuth2Util::getTokenProvider).thenReturn(tokenProvider);
 
             this.introspectionResponseDTO.setTokenType("Bearer");
 

--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
         <carbon.identity.version>7.8.506</carbon.identity.version>
         <carbon.identity.application.common.version>5.25.305</carbon.identity.application.common.version>
         <carbon.utils.version>4.9.10</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>7.0.286</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.34</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>7.8.506</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
Public Issue: https://github.com/wso2/product-is/issues/24066

This pull request refactors how the `TokenProvider` is accessed within the DPoP (Demonstration of Proof-of-Possession) module. The main change is to remove the custom service injection and storage of the `TokenProvider` in `DPoPDataHolder`, and instead use the standard `OAuth2Util.getTokenProvider()` approach throughout the codebase. This simplifies the code and aligns it with common patterns used elsewhere in the project. Additionally, the test code is updated to mock the new static access pattern, and a dependency version is updated in the build configuration.

**Refactoring and Simplification:**

* Removed the `TokenProvider` field, getter/setter, and related OSGi service injection from `DPoPDataHolder` and `DPoPServiceComponent`, eliminating custom management of the token provider. [[1]](diffhunk://#diff-587633016e68683306bfe6060139bc0e049909273313336845818f9bf192f0afL21-L22) [[2]](diffhunk://#diff-587633016e68683306bfe6060139bc0e049909273313336845818f9bf192f0afL33) [[3]](diffhunk://#diff-587633016e68683306bfe6060139bc0e049909273313336845818f9bf192f0afL75-L97) [[4]](diffhunk://#diff-1d53a82c2769b496053d969ed842e4f4c0bf217d9b292dda977b690a8442b094L38) [[5]](diffhunk://#diff-1d53a82c2769b496053d969ed842e4f4c0bf217d9b292dda977b690a8442b094L62) [[6]](diffhunk://#diff-1d53a82c2769b496053d969ed842e4f4c0bf217d9b292dda977b690a8442b094L125-L147)
* Updated `DPoPIntrospectionDataProvider` to use `OAuth2Util.getTokenProvider()` instead of accessing the `TokenProvider` via `DPoPDataHolder`, and adjusted token retrieval logic to use standard methods. [[1]](diffhunk://#diff-4aa3743d71cf7e044961b83b953c3ef1f17fd30a9d6b4acf583e0d9d4ffbacfeL27) [[2]](diffhunk://#diff-4aa3743d71cf7e044961b83b953c3ef1f17fd30a9d6b4acf583e0d9d4ffbacfeL53-R56)

**Test Updates:**

* Refactored tests in `DPoPIntrospectionDataProviderTest` to mock `OAuth2Util.getTokenProvider()` and removed references to the old injection pattern, ensuring tests align with the new static access pattern. [[1]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aL27-L31) [[2]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aL40-R39) [[3]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aL61-L63) [[4]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aL96-R95) [[5]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aR105) [[6]](diffhunk://#diff-373d87ebdae168aeed9ea6ca3d863b50a7e30f3e5b5ea5a27f54a3ed7f6e4a4aL120-R119)

**Dependency Update:**

* Updated the Maven dependency version for `identity.inbound.auth.oauth` from `7.0.286` to `7.4.34` in `pom.xml`.